### PR TITLE
[Feature] Add support to optionally fix wheel joints

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The above ROBILE bricks can be used to construct customized platform's. We descr
     <?xml version='1.0'?>
     <robot xmlns:xacro="http://ros.org/wiki/xacro" name="simple_config" >
 
+        <xacro:arg name="movable_joints" default="true"/>
+
         <!-- Include desired robile bricks -->
         <xacro:include filename="$(find robile_description)/urdf/robile_bricks/robile_active_wheel_brick.urdf.xacro" />
         <xacro:include filename="$(find robile_description)/urdf/robile_bricks/robile_passive_wheel_brick.urdf.xacro" />
@@ -42,19 +44,19 @@ Therefore we instantiate the ROBILE bricks as follows. We can use arbitrary name
 
 ~~~ xml
 <!-- Build platform using robile bricks -->
-<xacro:robile_passive_wheel_brick name="robile_1" parent="base_link">
+<xacro:robile_passive_wheel_brick name="robile_1" parent="base_link" movable_joints="$(arg movable_joints)">
     <origin xyz="0.1165 0.1165 0.05" rpy="0.0 0.0 0.0"/>
 </xacro:robile_passive_wheel_brick>
 
-<xacro:robile_passive_wheel_brick name="robile_2" parent="base_link">
+<xacro:robile_passive_wheel_brick name="robile_2" parent="base_link" movable_joints="$(arg movable_joints)">
     <origin xyz="0.1165 -0.1165 0.05" rpy="0.0 0.0 0.0"/>
 </xacro:robile_passive_wheel_brick>
 
-<xacro:robile_active_wheel_brick name="robile_3" parent="base_link">
+<xacro:robile_active_wheel_brick name="robile_3" parent="base_link" movable_joints="$(arg movable_joints)">
     <origin xyz="-0.1165 -0.1165 0.05" rpy="0.0 0.0 0.0"/>
 </xacro:robile_active_wheel_brick>
 
-<xacro:robile_active_wheel_brick name="robile_4" parent="base_link">
+<xacro:robile_active_wheel_brick name="robile_4" parent="base_link" movable_joints="$(arg movable_joints)">
     <origin xyz="-0.1165 0.1165 0.05" rpy="0.0 0.0 0.0"/>
 </xacro:robile_active_wheel_brick>
 ~~~
@@ -67,6 +69,8 @@ The complete platform configuration file `robots/simple_config.urdf.xacro` would
 <?xml version='1.0'?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="simple_config" >
 
+    <xacro:arg name="movable_joints" default="true"/>
+
     <!-- Include desired robile bricks -->
     <xacro:include filename="$(find robile_description)/urdf/robile_bricks/robile_active_wheel_brick.urdf.xacro" />
     <xacro:include filename="$(find robile_description)/urdf/robile_bricks/robile_passive_wheel_brick.urdf.xacro" />
@@ -74,19 +78,19 @@ The complete platform configuration file `robots/simple_config.urdf.xacro` would
     <link name="base_link"/>
 
     <!-- Build platform using robile bricks -->
-    <xacro:robile_passive_wheel_brick name="robile_1" parent="base_link">
+    <xacro:robile_passive_wheel_brick name="robile_1" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="0.1165 0.1165 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_passive_wheel_brick>
 
-    <xacro:robile_passive_wheel_brick name="robile_2" parent="base_link">
+    <xacro:robile_passive_wheel_brick name="robile_2" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="0.1165 -0.1165 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_passive_wheel_brick>
 
-    <xacro:robile_active_wheel_brick name="robile_3" parent="base_link">
+    <xacro:robile_active_wheel_brick name="robile_3" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="-0.1165 -0.1165 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_active_wheel_brick>
 
-    <xacro:robile_active_wheel_brick name="robile_4" parent="base_link">
+    <xacro:robile_active_wheel_brick name="robile_4" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="-0.1165 0.1165 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_active_wheel_brick>
 

--- a/gazebo/gazebo_ros_planar_move.xacro
+++ b/gazebo/gazebo_ros_planar_move.xacro
@@ -1,11 +1,12 @@
 <?xml version='1.0'?>
 
 <!--
-Copyright (c) 2021
+Copyright (c) 2022
 KELO Robotics GmbH
 
 Author:
 Sushant Chavan
+Walter Nowak
 
 
 This software is published under a dual-license: GNU Lesser General Public
@@ -38,22 +39,14 @@ You should have received a copy of the GNU Lesser General Public
 License LGPL and BSD license along with this program.
 -->
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro" name="robile_platform_gazebo">
-
-    <!-- Args are global and hence all included xacro files will also receive them 
-    https://github.com/ros/xacro/issues/204#issuecomment-852096062 -->
-    <xacro:arg name="platform_config" default="" />
-    <xacro:arg name="movable_joints" default="true" />
-
-    <!-- Include the xacro file to instantiate the robot -->
-    <xacro:include filename="$(find robile_description)/robots/$(arg platform_config).urdf.xacro" />
-
-    <xacro:if value="$(arg movable_joints)">
-        <!-- Include the xacro file to start gazebo ros control plugin -->
-        <xacro:include filename="$(find robile_description)/gazebo/gazebo_ros_control.xacro" />
-    </xacro:if>
-    <xacro:unless value="$(arg movable_joints)">
-        <!-- Include the xacro file to start gazebo ros planar move plugin -->
-        <xacro:include filename="$(find robile_description)/gazebo/gazebo_ros_planar_move.xacro" />
-    </xacro:unless>
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="gazebo_ros_planar_move">
+    <gazebo>
+        <plugin name="gazebo_ros_planar_move" filename="libgazebo_ros_planar_move.so">
+            <commandTopic>cmd_vel</commandTopic>
+            <odometryTopic>odom</odometryTopic>
+            <odometryFrame>odom</odometryFrame>
+            <odometryRate>20.0</odometryRate>
+            <robotBaseFrame>base_link</robotBaseFrame>
+        </plugin>
+    </gazebo>
 </robot>

--- a/robots/2_wheel_config.urdf.xacro
+++ b/robots/2_wheel_config.urdf.xacro
@@ -40,6 +40,8 @@ License LGPL and BSD license along with this program.
 
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="2_wheel_config" >
 
+    <xacro:arg name="movable_joints" default="true"/>
+
     <!-- Include desired robile bricks -->
     <xacro:include filename="$(find robile_description)/urdf/robile_bricks/robile_active_wheel_brick.urdf.xacro" />
     <xacro:include filename="$(find robile_description)/urdf/robile_bricks/robile_passive_wheel_brick.urdf.xacro" />
@@ -49,11 +51,11 @@ License LGPL and BSD license along with this program.
     <link name="base_link"/>
 
     <!-- Build platform using robile bricks -->
-    <xacro:robile_passive_wheel_brick name="robile_1" parent="base_link">
+    <xacro:robile_passive_wheel_brick name="robile_1" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="0.233 0.1165 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_passive_wheel_brick>
 
-    <xacro:robile_passive_wheel_brick name="robile_2" parent="base_link">
+    <xacro:robile_passive_wheel_brick name="robile_2" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="0.233 -0.1165 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_passive_wheel_brick>
 
@@ -65,11 +67,11 @@ License LGPL and BSD license along with this program.
         <origin xyz="0.0 -0.1165 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_master_battery_brick>
 
-    <xacro:robile_active_wheel_brick name="robile_5" parent="base_link">
+    <xacro:robile_active_wheel_brick name="robile_5" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="-0.233 0.1165 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_active_wheel_brick>
 
-    <xacro:robile_active_wheel_brick name="robile_6" parent="base_link">
+    <xacro:robile_active_wheel_brick name="robile_6" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="-0.233 -0.1165 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_active_wheel_brick>
 </robot>

--- a/robots/4_wheel_config.urdf.xacro
+++ b/robots/4_wheel_config.urdf.xacro
@@ -40,6 +40,8 @@ License LGPL and BSD license along with this program.
 
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="4_wheel_config" >
 
+    <xacro:arg name="movable_joints" default="true"/>
+
     <!-- Include desired robile bricks -->
     <xacro:include filename="$(find robile_description)/urdf/robile_bricks/robile_active_wheel_brick.urdf.xacro" />
     <xacro:include filename="$(find robile_description)/urdf/robile_bricks/robile_cpu_brick.urdf.xacro" />
@@ -48,11 +50,11 @@ License LGPL and BSD license along with this program.
     <link name="base_link"/>
 
     <!-- Build platform using robile bricks -->
-    <xacro:robile_active_wheel_brick name="robile_1" parent="base_link">
+    <xacro:robile_active_wheel_brick name="robile_1" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="0.233 0.1165 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_active_wheel_brick>
 
-    <xacro:robile_active_wheel_brick name="robile_2" parent="base_link">
+    <xacro:robile_active_wheel_brick name="robile_2" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="0.233 -0.1165 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_active_wheel_brick>
 
@@ -64,11 +66,11 @@ License LGPL and BSD license along with this program.
         <origin xyz="0.0 -0.1165 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_master_battery_brick>
 
-    <xacro:robile_active_wheel_brick name="robile_5" parent="base_link">
+    <xacro:robile_active_wheel_brick name="robile_5" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="-0.233 0.1165 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_active_wheel_brick>
 
-    <xacro:robile_active_wheel_brick name="robile_6" parent="base_link">
+    <xacro:robile_active_wheel_brick name="robile_6" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="-0.233 -0.1165 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_active_wheel_brick>
 </robot>

--- a/robots/6_wheel_config.urdf.xacro
+++ b/robots/6_wheel_config.urdf.xacro
@@ -40,6 +40,8 @@ License LGPL and BSD license along with this program.
 
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="6_wheel_config" >
 
+    <xacro:arg name="movable_joints" default="true"/>
+
     <!-- Include desired robile bricks -->
     <xacro:include filename="$(find robile_description)/urdf/robile_bricks/robile_active_wheel_brick.urdf.xacro" />
     <xacro:include filename="$(find robile_description)/urdf/robile_bricks/robile_cpu_brick.urdf.xacro" />
@@ -49,7 +51,7 @@ License LGPL and BSD license along with this program.
     <link name="base_link"/>
 
     <!-- Build platform using robile bricks -->
-    <xacro:robile_active_wheel_brick name="robile_1" parent="base_link">
+    <xacro:robile_active_wheel_brick name="robile_1" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="0.233 0.466 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_active_wheel_brick>
 
@@ -57,7 +59,7 @@ License LGPL and BSD license along with this program.
         <origin xyz="0 0.466 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_empty_brick>
 
-    <xacro:robile_active_wheel_brick name="robile_3" parent="base_link">
+    <xacro:robile_active_wheel_brick name="robile_3" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="-0.233 0.466 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_active_wheel_brick>
 
@@ -73,7 +75,7 @@ License LGPL and BSD license along with this program.
         <origin xyz="-0.233 0.233 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_empty_brick>
 
-    <xacro:robile_active_wheel_brick name="robile_7" parent="base_link">
+    <xacro:robile_active_wheel_brick name="robile_7" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="0.233 0 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_active_wheel_brick>
 
@@ -81,7 +83,7 @@ License LGPL and BSD license along with this program.
         <origin xyz="0 0 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_empty_brick>
 
-    <xacro:robile_active_wheel_brick name="robile_9" parent="base_link">
+    <xacro:robile_active_wheel_brick name="robile_9" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="-0.233 0 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_active_wheel_brick>
 
@@ -97,7 +99,7 @@ License LGPL and BSD license along with this program.
         <origin xyz="-0.233 -0.233 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_empty_brick>
 
-    <xacro:robile_active_wheel_brick name="robile_13" parent="base_link">
+    <xacro:robile_active_wheel_brick name="robile_13" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="0.233 -0.466 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_active_wheel_brick>
 
@@ -105,7 +107,7 @@ License LGPL and BSD license along with this program.
         <origin xyz="0 -0.466 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_empty_brick>
 
-    <xacro:robile_active_wheel_brick name="robile_15" parent="base_link">
+    <xacro:robile_active_wheel_brick name="robile_15" parent="base_link" movable_joints="$(arg movable_joints)">
         <origin xyz="-0.233 -0.466 0.05" rpy="0.0 0.0 0.0"/>
     </xacro:robile_active_wheel_brick>
 

--- a/urdf/base_macros/kelo_drive.urdf.xacro
+++ b/urdf/base_macros/kelo_drive.urdf.xacro
@@ -40,29 +40,39 @@ License LGPL and BSD license along with this program.
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-    <xacro:macro name="kelo_drive" params="name parent *origin">
+    <xacro:macro name="kelo_drive" params="name parent *origin movable_joints:=true">
 
         <xacro:include filename="$(find robile_description)/urdf/base_macros/common.xacro" />
         <xacro:include filename="$(find robile_description)/urdf/base_macros/kelo_drive_wheel.urdf.xacro" />
 
         <!-- PIVOT -->
-        <joint name="${name}_pivot_joint" type="continuous">
-            <xacro:insert_block name="origin" />
-            <axis xyz="0 0 1"/>
-            <parent link="${parent}"/>
-            <child link="${name}_pivot_link" />
-        </joint>
-
-        <transmission name="${name}_pivot_transmission">
-            <type>transmission_interface/SimpleTransmission</type>
-            <joint name="${name}_pivot_joint">
-                <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+        <xacro:if value="${movable_joints}">
+            <joint name="${name}_pivot_joint" type="continuous">
+                <xacro:insert_block name="origin" />
+                <axis xyz="0 0 1"/>
+                <parent link="${parent}"/>
+                <child link="${name}_pivot_link" />
             </joint>
-            <actuator name="${name}_pivot_motor">
-                <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
-                <mechanicalReduction>1</mechanicalReduction>
-            </actuator>
-        </transmission>
+
+            <transmission name="${name}_pivot_transmission">
+                <type>transmission_interface/SimpleTransmission</type>
+                <joint name="${name}_pivot_joint">
+                    <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+                </joint>
+                <actuator name="${name}_pivot_motor">
+                    <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+                    <mechanicalReduction>1</mechanicalReduction>
+                </actuator>
+            </transmission>
+        </xacro:if>
+        <xacro:unless value="${movable_joints}">
+            <joint name="${name}_pivot_joint" type="fixed">
+                <xacro:insert_block name="origin" />
+                <axis xyz="0 0 1"/>
+                <parent link="${parent}"/>
+                <child link="${name}_pivot_link" />
+            </joint>
+        </xacro:unless>
 
         <link name="${name}_pivot_link">
             <visual>
@@ -85,12 +95,12 @@ License LGPL and BSD license along with this program.
         </link>
 
         <!-- LEFT HUB WHEEL -->
-        <xacro:kelo_drive_wheel name="${name}_left_hub_wheel" parent="${name}_pivot_link">
+        <xacro:kelo_drive_wheel name="${name}_left_hub_wheel" parent="${name}_pivot_link" movable_joints="${movable_joints}">
             <origin xyz="-0.01 0.039326 0.001514" rpy="0 0 0.0"/>
         </xacro:kelo_drive_wheel>
 
         <!-- RIGHT HUB WHEEL -->
-        <xacro:kelo_drive_wheel name="${name}_right_hub_wheel" parent="${name}_pivot_link">
+        <xacro:kelo_drive_wheel name="${name}_right_hub_wheel" parent="${name}_pivot_link" movable_joints="${movable_joints}">
             <origin xyz="-0.01 -0.039326 0.001514" rpy="0 0 0.0"/>
         </xacro:kelo_drive_wheel>
 

--- a/urdf/base_macros/kelo_drive_wheel.urdf.xacro
+++ b/urdf/base_macros/kelo_drive_wheel.urdf.xacro
@@ -40,27 +40,37 @@ License LGPL and BSD license along with this program.
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-    <xacro:macro name="kelo_drive_wheel" params="name parent *origin">
+    <xacro:macro name="kelo_drive_wheel" params="name parent *origin movable_joints:=true">
 
         <xacro:include filename="$(find robile_description)/urdf/base_macros/common.xacro" />
 
-        <joint name="${name}_joint" type="continuous">
-            <xacro:insert_block name="origin" />
-            <axis xyz="0 1 0"/>
-            <parent link="${parent}"/>
-            <child link="${name}_link" />
-        </joint>
-
-        <transmission name="${name}_transmission">
-            <type>transmission_interface/SimpleTransmission</type>
-            <joint name="${name}_joint">
-                <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+        <xacro:if value="${movable_joints}">
+            <joint name="${name}_joint" type="continuous">
+                <xacro:insert_block name="origin" />
+                <axis xyz="0 1 0"/>
+                <parent link="${parent}"/>
+                <child link="${name}_link" />
             </joint>
-            <actuator name="${name}_motor">
-                <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
-                <mechanicalReduction>1</mechanicalReduction>
-            </actuator>
-        </transmission>
+
+            <transmission name="${name}_transmission">
+                <type>transmission_interface/SimpleTransmission</type>
+                <joint name="${name}_joint">
+                    <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+                </joint>
+                <actuator name="${name}_motor">
+                    <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+                    <mechanicalReduction>1</mechanicalReduction>
+                </actuator>
+            </transmission>
+        </xacro:if>
+        <xacro:unless value="${movable_joints}">
+            <joint name="${name}_joint" type="fixed">
+                <xacro:insert_block name="origin" />
+                <axis xyz="0 1 0"/>
+                <parent link="${parent}"/>
+                <child link="${name}_link" />
+            </joint>
+        </xacro:unless>
 
         <link name="${name}_link">
             <visual>

--- a/urdf/base_macros/passive_caster_wheel.urdf.xacro
+++ b/urdf/base_macros/passive_caster_wheel.urdf.xacro
@@ -40,28 +40,38 @@ License LGPL and BSD license along with this program.
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-    <xacro:macro name="passive_caster_wheel" params="name parent *origin">
+    <xacro:macro name="passive_caster_wheel" params="name parent *origin movable_joints:=true">
 
         <xacro:include filename="$(find robile_description)/urdf/base_macros/common.xacro" />
 
         <!-- PIVOT -->
-        <joint name="${name}_pivot_caster_joint" type="continuous">
-            <xacro:insert_block name="origin" />
-            <axis xyz="0 0 1"/>
-            <parent link="${parent}"/>
-            <child link="${name}_pivot_link" />
-        </joint>
-
-        <transmission name="${name}_pivot_transmission">
-            <type>transmission_interface/SimpleTransmission</type>
-            <joint name="${name}_pivot_caster_joint">
-                <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+        <xacro:if value="${movable_joints}">
+            <joint name="${name}_pivot_caster_joint" type="continuous">
+                <xacro:insert_block name="origin" />
+                <axis xyz="0 0 1"/>
+                <parent link="${parent}"/>
+                <child link="${name}_pivot_link" />
             </joint>
-            <actuator name="${name}_pivot_motor">
-                <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
-                <mechanicalReduction>1</mechanicalReduction>
-            </actuator>
-        </transmission>
+
+            <transmission name="${name}_pivot_transmission">
+                <type>transmission_interface/SimpleTransmission</type>
+                <joint name="${name}_pivot_caster_joint">
+                    <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+                </joint>
+                <actuator name="${name}_pivot_motor">
+                    <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+                    <mechanicalReduction>1</mechanicalReduction>
+                </actuator>
+            </transmission>
+        </xacro:if>
+        <xacro:unless value="${movable_joints}">
+            <joint name="${name}_pivot_caster_joint" type="fixed">
+                <xacro:insert_block name="origin" />
+                <axis xyz="0 0 1"/>
+                <parent link="${parent}"/>
+                <child link="${name}_pivot_link" />
+            </joint>
+        </xacro:unless>
 
         <link name="${name}_pivot_link">
             <visual>
@@ -86,23 +96,33 @@ License LGPL and BSD license along with this program.
         </link>
 
         <!-- CASTER WHEEL -->
-        <joint name="${name}_wheel_joint" type="continuous">
-            <origin xyz="0 0 0" rpy="0 0 0"/>
-            <axis xyz="0 1 0"/>
-            <parent link="${name}_caster_offset_link"/>
-            <child link="${name}_wheel_link" />
-        </joint>
-
-        <transmission name="${name}_wheel_transmission">
-            <type>transmission_interface/SimpleTransmission</type>
-            <joint name="${name}_wheel_joint">
-                <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+        <xacro:if value="${movable_joints}">
+            <joint name="${name}_wheel_joint" type="continuous">
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <axis xyz="0 1 0"/>
+                <parent link="${name}_caster_offset_link"/>
+                <child link="${name}_wheel_link" />
             </joint>
-            <actuator name="${name}_wheel_motor">
-                <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
-                <mechanicalReduction>1</mechanicalReduction>
-            </actuator>
-        </transmission>
+
+            <transmission name="${name}_wheel_transmission">
+                <type>transmission_interface/SimpleTransmission</type>
+                <joint name="${name}_wheel_joint">
+                    <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+                </joint>
+                <actuator name="${name}_wheel_motor">
+                    <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+                    <mechanicalReduction>1</mechanicalReduction>
+                </actuator>
+            </transmission>
+        </xacro:if>
+        <xacro:unless value="${movable_joints}">
+            <joint name="${name}_wheel_joint" type="fixed">
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <axis xyz="0 1 0"/>
+                <parent link="${name}_caster_offset_link"/>
+                <child link="${name}_wheel_link" />
+            </joint>
+        </xacro:unless>
 
         <link name="${name}_wheel_link">
             <visual>

--- a/urdf/robile_bricks/robile_active_wheel_brick.urdf.xacro
+++ b/urdf/robile_bricks/robile_active_wheel_brick.urdf.xacro
@@ -40,7 +40,7 @@ License LGPL and BSD license along with this program.
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-    <xacro:macro name="robile_active_wheel_brick" params="name parent *origin">
+    <xacro:macro name="robile_active_wheel_brick" params="name parent *origin movable_joints:=true">
 
         <!-- Include xacro files-->
         <xacro:include filename="$(find robile_description)/urdf/base_macros/brick_housing.urdf.xacro" />
@@ -54,7 +54,7 @@ License LGPL and BSD license along with this program.
 
         <xacro:brick_housing name="${name}" with_wheel="true" color="red"/>
 
-        <xacro:kelo_drive name="${name}_drive" parent="${name}_link">
+        <xacro:kelo_drive name="${name}_drive" parent="${name}_link" movable_joints="${movable_joints}">
             <origin xyz="0 0 0" rpy="0 0 0.0"/>
         </xacro:kelo_drive>
 

--- a/urdf/robile_bricks/robile_passive_wheel_brick.urdf.xacro
+++ b/urdf/robile_bricks/robile_passive_wheel_brick.urdf.xacro
@@ -40,7 +40,7 @@ License LGPL and BSD license along with this program.
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-    <xacro:macro name="robile_passive_wheel_brick" params="name parent *origin">
+    <xacro:macro name="robile_passive_wheel_brick" params="name parent *origin movable_joints:=true">
 
         <!-- Include xacro files-->
         <xacro:include filename="$(find robile_description)/urdf/base_macros/brick_housing.urdf.xacro" />
@@ -54,7 +54,7 @@ License LGPL and BSD license along with this program.
 
         <xacro:brick_housing name="${name}" with_wheel="true" color="blue"/>
 
-        <xacro:passive_caster_wheel name="${name}_caster_wheel" parent="${name}_link">
+        <xacro:passive_caster_wheel name="${name}_caster_wheel" parent="${name}_link" movable_joints="${movable_joints}">
             <origin xyz="0 0 0" rpy="0 0 0.0"/>
         </xacro:passive_caster_wheel>
 


### PR DESCRIPTION
This PR enables the robot models to be instantiated with fixed joints for all the KELO Drives. This can be useful when simulating the robile bricks without using the [kelo_tulip](https://github.com/kelo-robotics/kelo_tulip) platform controller.